### PR TITLE
공지사항 삭제 기능 추가 

### DIFF
--- a/src/main/java/com/gworld/manage/common/model/ResponseResult.java
+++ b/src/main/java/com/gworld/manage/common/model/ResponseResult.java
@@ -2,7 +2,6 @@ package com.gworld.manage.common.model;
 
 import lombok.Data;
 
-//@Data
 public class ResponseResult {
     ResponseResultHeader header;
     Object body;

--- a/src/main/java/com/gworld/manage/common/model/ResponseResult.java
+++ b/src/main/java/com/gworld/manage/common/model/ResponseResult.java
@@ -1,0 +1,15 @@
+package com.gworld.manage.common.model;
+
+import lombok.Data;
+
+//@Data
+public class ResponseResult {
+    ResponseResultHeader header;
+    Object body;
+    public ResponseResult(boolean result, String message){
+        header = new ResponseResultHeader(result, message);
+    }
+    public ResponseResult(boolean result){
+        header = new ResponseResultHeader(result);
+    }
+}

--- a/src/main/java/com/gworld/manage/common/model/ResponseResultHeader.java
+++ b/src/main/java/com/gworld/manage/common/model/ResponseResultHeader.java
@@ -1,0 +1,17 @@
+package com.gworld.manage.common.model;
+
+import lombok.Data;
+
+@Data
+public class ResponseResultHeader {
+    boolean result;
+    String message;
+
+    public ResponseResultHeader(boolean result, String message) {
+        this.result = result;
+        this.message = message;
+    }
+    public ResponseResultHeader(boolean result){
+        this.result = result;
+    }
+}

--- a/src/main/java/com/gworld/manage/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/gworld/manage/configuration/SecurityConfiguration.java
@@ -1,0 +1,26 @@
+package com.gworld.manage.configuration;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+
+@RequiredArgsConstructor
+@EnableWebSecurity
+@Configuration
+public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http.csrf().disable();
+        http.headers().frameOptions().sameOrigin();
+
+        http.authorizeRequests()
+                .antMatchers( // 로그인이 없어도 접근 가능한 위치를 정의
+                        "/**"
+                ).permitAll();
+
+        super.configure(http);
+    }
+}

--- a/src/main/java/com/gworld/manage/controller/ApiNoticeController.java
+++ b/src/main/java/com/gworld/manage/controller/ApiNoticeController.java
@@ -1,0 +1,30 @@
+package com.gworld.manage.controller;
+
+import com.gworld.manage.common.model.ResponseResult;
+import com.gworld.manage.model.BoardDto;
+import com.gworld.manage.model.ServiceResult;
+import com.gworld.manage.service.NoticeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+public class ApiNoticeController {
+    private final NoticeService noticeService;
+
+    @PostMapping("/api/notice/del.api")
+    public ResponseEntity<?> del(
+            @RequestBody BoardDto boardDto
+    ){
+        ServiceResult result = noticeService.delete(boardDto.getId());
+        if(!result.isResult()){
+            ResponseResult responseResult = new ResponseResult(false, result.getMessage());
+            return ResponseEntity.ok().body(responseResult);
+        }
+        ResponseResult responseResult = new ResponseResult(true);
+        return ResponseEntity.ok().body(responseResult);
+    }
+}

--- a/src/main/java/com/gworld/manage/model/ServiceResult.java
+++ b/src/main/java/com/gworld/manage/model/ServiceResult.java
@@ -1,0 +1,17 @@
+package com.gworld.manage.model;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class ServiceResult {
+    private boolean result;
+    private String message;
+
+    public ServiceResult(boolean result, String message) {
+        this.result = result;
+        this.message = message;
+    }
+    public ServiceResult(boolean result){ this.result = result; }
+}

--- a/src/main/java/com/gworld/manage/service/NoticeService.java
+++ b/src/main/java/com/gworld/manage/service/NoticeService.java
@@ -2,6 +2,7 @@ package com.gworld.manage.service;
 
 import com.gworld.manage.model.Board;
 import com.gworld.manage.model.BoardDto;
+import com.gworld.manage.model.ServiceResult;
 
 import java.util.List;
 
@@ -9,4 +10,6 @@ public interface NoticeService {
     List<Board> list();
 
     BoardDto detail(long id);
+
+    ServiceResult delete(Long id);
 }

--- a/src/main/java/com/gworld/manage/service/NoticeServiceImpl.java
+++ b/src/main/java/com/gworld/manage/service/NoticeServiceImpl.java
@@ -2,6 +2,7 @@ package com.gworld.manage.service;
 
 import com.gworld.manage.model.Board;
 import com.gworld.manage.model.BoardDto;
+import com.gworld.manage.model.ServiceResult;
 import com.gworld.manage.repository.BoardRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -29,5 +30,25 @@ public class NoticeServiceImpl implements NoticeService {
         Board board = optionalBoard.get();
 
         return BoardDto.of(board);
+    }
+
+    @Override
+    public ServiceResult delete(Long id) {
+        ServiceResult result = new ServiceResult();
+
+        Optional<Board> optionalBoard = boardRepository.findById(id);
+        if(optionalBoard.isEmpty()){
+            result.setResult(false);
+            result.setMessage("게시글 정보가 존재하지 않습니다.");
+            return result;
+        }
+
+        Board board = optionalBoard.get();
+        board.setDelete_yn(true);
+        boardRepository.save(board);
+
+        result.setResult(true);
+        result.setMessage("");
+        return result;
     }
 }

--- a/src/main/resources/templates/notices/detail.html
+++ b/src/main/resources/templates/notices/detail.html
@@ -3,7 +3,46 @@
 <head>
     <meta charset="UTF-8">
     <title>Title</title>
+    <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js" integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=" crossorigin="anonymous"></script>
+    <script>
+        $(function (){
+            $('#deleteForm').on('submit', function(){
+                if(!confirm('정말 삭제하시겠습니까?')){
+                    return false;
+                }
+
+                var $this = $(this);
+                var url = '/api/notice/del.api';
+                var parameter = {
+                    id : $this.find('input[name=id]').val()
+                };
+
+                axios.post(url, parameter).then(function(response){
+                    console.log(response);
+                    response.data = response.data || {};
+                    response.data.header = response.data.header || {};
+
+                    if(!response.data.header.result){
+                        alert(response.data.header.message);
+                        return false;
+                    }
+                    // console.log(response.data);
+                    // console.log(response.data.header);
+                    alert('삭제되었습니다.');
+                    location.href ='/notice/list.do';
+                }).catch(function(err){
+                    alert('삭제를 실패했습니다.');
+                    console.log(err);
+                });
+
+                return false;
+            });
+        });
+
+    </script>
 </head>
+
 <body>
 <h1>공지사항 상세</h1>
 <div th:replace="/fragments/layout.html :: fragment-body-menu"></div>
@@ -27,6 +66,11 @@
         </tr>
         </tbody>
     </table>
+
+    <form method="post" id="deleteForm">
+        <input type="hidden" name="id" id="id" th:value="${board.id}">
+        <button type="submit">삭제</button>
+    </form>
     <a href="list.do">목록으로</a>
 </body>
 </html>

--- a/src/test/java/com/gworld/manage/service/NoticeServiceImplTest.java
+++ b/src/test/java/com/gworld/manage/service/NoticeServiceImplTest.java
@@ -1,8 +1,14 @@
 package com.gworld.manage.service;
 
+import com.gworld.manage.common.model.ResponseResult;
 import com.gworld.manage.model.Board;
 import com.gworld.manage.model.BoardDto;
+import com.gworld.manage.model.ServiceResult;
 import com.gworld.manage.repository.BoardRepository;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -10,7 +16,16 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.sql.Timestamp;
+import java.text.SimpleDateFormat;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.Locale;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -55,5 +70,60 @@ class NoticeServiceImplTest {
         assertEquals("author", boardDto.getAuthor());
         assertEquals(now, boardDto.getRegister_date());
         assertEquals(now, boardDto.getUpdate_date());
+    }
+
+    @Test
+    @DisplayName("삭제 처리 성공")
+    void deleteSuccess(){
+        LocalDateTime now = LocalDateTime.now();
+        Board board = Board.builder()
+                .id(1L)
+                .title("title")
+                .content("content")
+                .hit(1)
+                .author("author")
+                .register_date(now)
+                .update_date(now)
+                .delete_yn(false)
+                .build();
+
+        // given
+        given(boardRepository.findById(anyLong()))
+                .willReturn(Optional.of(board));
+
+        // when
+        ServiceResult result = noticeService.delete(anyLong());
+
+        //then
+        assertTrue(result.isResult());
+        assertEquals("", result.getMessage());
+        assertTrue(board.isDelete_yn());
+    }
+    @Test
+    @DisplayName("long id가 잘못되었을때 실패 처리")
+    void deleteFail(){
+        LocalDateTime now = LocalDateTime.now();
+        Board board = Board.builder()
+                .id(1L)
+                .title("title")
+                .content("content")
+                .hit(1)
+                .author("author")
+                .register_date(now)
+                .update_date(now)
+                .delete_yn(false)
+                .build();
+
+        // given
+        given(boardRepository.findById(anyLong()))
+                .willReturn(Optional.empty());
+
+        // when
+        ServiceResult result = noticeService.delete(anyLong());
+
+        //then
+        assertFalse(result.isResult());
+        assertEquals("게시글 정보가 존재하지 않습니다.", result.getMessage());
+        assertFalse(board.isDelete_yn());
     }
 }


### PR DESCRIPTION
NoticeServiceImpl
- 삭제 기능 구현
- 삭제를 시도한 사람이 관리자인지 or 작성자인지 체크하는 로직을 아직 넣지 않았습니다(유저 권한 정의 후 다음에 추가 예정)

ResponseResult, ResponseResultHeader
- Controller에서 return 받을 스펙을 정의 

ServiceResult
- Service에서 return 받을 스펙을 정의 

SecurityConfiguration
- 개발을 편하게 하고자 Security 설정으로 로그인을 없앰 

테스트 코드 작성 완료 
- 삭제 성공 케이스(deleteSuccess)
- 삭제 실패 케이스(deleteFail)